### PR TITLE
10 21 test debugging

### DIFF
--- a/virtuoso_perception/config/roboboat/ground_filter.yaml
+++ b/virtuoso_perception/config/roboboat/ground_filter.yaml
@@ -2,4 +2,4 @@
 /**:
   ros__parameters:
     frame_for_filtering: ''
-    sensor_height: 1.1
+    frame_height: 1.1

--- a/virtuoso_perception/config/roboboat/lidar_processing.yaml
+++ b/virtuoso_perception/config/roboboat/lidar_processing.yaml
@@ -11,7 +11,8 @@ processing_shore_filter:
 
 processing_voxels:
   ros__parameters:
+    debug: False
     leaf_size:
-      x: 0.01
-      y: 0.01
-      z: 0.01
+      x: 0.05
+      y: 0.05
+      z: 0.05

--- a/virtuoso_perception/config/vrx_roboboat/lidar_processing.yaml
+++ b/virtuoso_perception/config/vrx_roboboat/lidar_processing.yaml
@@ -11,6 +11,7 @@ processing_shore_filter:
 
 processing_voxels:
   ros__parameters:
+    debug: False
     leaf_size:
       x: 0.01
       y: 0.01

--- a/virtuoso_perception/virtuoso_perception/lidar_processing/voxels_node.cpp
+++ b/virtuoso_perception/virtuoso_perception/lidar_processing/voxels_node.cpp
@@ -26,6 +26,13 @@ class VoxelsNode : public rclcpp::Node {
         pcl::PointCloud<pcl::PointXYZ>::Ptr temp_cloud(new pcl::PointCloud<pcl::PointXYZ>);
         pcl::fromPCLPointCloud2(pcl_pc2, *temp_cloud);
 
+        if (this->get_parameter("debug").as_bool()) {
+            RCLCPP_INFO(
+                this->get_logger(), 
+                ("Input size: " + std::to_string(temp_cloud->size())).c_str()
+            );
+        }
+
         pcl::PointCloud<pcl::PointXYZ>::Ptr cloud_f(new pcl::PointCloud<pcl::PointXYZ>);
 
         pcl::VoxelGrid<pcl::PointXYZ> vg;
@@ -37,6 +44,13 @@ class VoxelsNode : public rclcpp::Node {
             this->get_parameter("leaf_size.z").as_double()
         );
         vg.filter(*cloud_filtered);
+
+        if (this->get_parameter("debug").as_bool()) {
+            RCLCPP_INFO(
+                this->get_logger(), 
+                ("Output size: " + std::to_string(cloud_filtered->size())).c_str()
+            );
+        }
 
         sensor_msgs::msg::PointCloud2 pub_msg;
         pcl::toROSMsg(*cloud_filtered.get(), pub_msg);
@@ -53,6 +67,7 @@ class VoxelsNode : public rclcpp::Node {
 
             pcl::console::setVerbosityLevel(pcl::console::L_ALWAYS);
 
+            this->declare_parameter("debug", false);
             this->declare_parameter("leaf_size.x", 0.0);
             this->declare_parameter("leaf_size.y", 0.0);
             this->declare_parameter("leaf_size.z", 0.0);


### PR DESCRIPTION
During the 10/21 lake test euclidean clustering was not working. There were 2 problems:

1. Incorrect parameter name for the ground filter
2. Voxel grid leaf size was too small, rendering the filtering useless and overwhelming the euclidean clustering

Fixes have been made to parameters and, based on bagged data, appear to be resolved.